### PR TITLE
RPM name changed 

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -103,9 +103,9 @@ get_os_major_version_id () {
 do_rpm_install(){
   get_package "rpm"
   sleep 2
-  if rpm -q cyral-sidecar > /dev/null 2>&1; then
+  if rpm -q sidecar > /dev/null 2>&1; then
     echo "Removing existing installation..."
-    rpm -e --erase cyral-sidecar > /dev/null 2>&1
+    rpm -e --erase sidecar > /dev/null 2>&1
     rm -f "$(grep "discovery-database" /etc/cyral/cyral-service-monitor/config.yaml 2>/dev/null| awk '{print $2}')"
     rm -f /etc/cyral/conf.d/sidecar.db
   fi
@@ -116,9 +116,9 @@ do_rpm_install(){
 do_dpkg_install(){
   get_package "deb"
   sleep 2
-  if dpkg -s cyral-sidecar > /dev/null 2>&1; then
+  if dpkg -s sidecar > /dev/null 2>&1; then
     echo "Removing existing installation..."
-    dpkg -r cyral-sidecar > /dev/null 2>&1
+    dpkg -r sidecar > /dev/null 2>&1
     rm -f "$(grep "discovery-database" /etc/cyral/cyral-service-monitor/config.yaml 2>/dev/null| awk '{print $2}')"
     rm -f /etc/cyral/conf.d/sidecar.db
   fi

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -103,8 +103,10 @@ get_os_major_version_id () {
 do_rpm_install(){
   get_package "rpm"
   sleep 2
-  if rpm -q sidecar > /dev/null 2>&1; then
+  if rpm -q cyral-sidecar > /dev/null 2>&1 || rpm -q sidecar > /dev/null 2>&1; then
     echo "Removing existing installation..."
+    # Split this call in 2 because rpm wont uninstall any package if one or more dont exist
+    rpm -e --erase cyral-sidecar > /dev/null 2>&1
     rpm -e --erase sidecar > /dev/null 2>&1
     rm -f "$(grep "discovery-database" /etc/cyral/cyral-service-monitor/config.yaml 2>/dev/null| awk '{print $2}')"
     rm -f /etc/cyral/conf.d/sidecar.db
@@ -116,9 +118,9 @@ do_rpm_install(){
 do_dpkg_install(){
   get_package "deb"
   sleep 2
-  if dpkg -s sidecar > /dev/null 2>&1; then
+  if dpkg -s cyral-sidecar > /dev/null 2>&1 || dpkg -s sidecar > /dev/null 2>&1; then
     echo "Removing existing installation..."
-    dpkg -r sidecar > /dev/null 2>&1
+    dpkg -r cyral-sidecar sidecar > /dev/null 2>&1
     rm -f "$(grep "discovery-database" /etc/cyral/cyral-service-monitor/config.yaml 2>/dev/null| awk '{print $2}')"
     rm -f /etc/cyral/conf.d/sidecar.db
   fi


### PR DESCRIPTION
from cyral-sidecar to sidecar, so the script looked for Cyral-sidecar before uninstalling and installing and it failed. I update the install script to find it using sidecar and uninstall correctly.

Tested this by doing an rpm install with the previous script twice:
```
sudo .. bash -c "./install-linux.sh"
Doing a Red Hat Install
Downloading the binaries
Installing sidecar...
...

sudo ... bash -c "./install-linux.sh"
Doing a Red Hat Install
Downloading the binaries
...
Installing sidecar...
...
```

After modifying the script:

```
sudo ... bash -c "./install-linux.sh"
Doing a Red Hat Install
Downloading the binaries
...
Installing sidecar...
...

sudo ... bash -c "./install-linux.sh"
Doing a Red Hat Install
Downloading the binaries
...
Removing existing installation...
Installing sidecar...
...
```

Testing in ubuntu works as well:
```
sudo ... bash -c "./install-linux.sh"
Doing an Ubuntu Install
Downloading the binaries
...
Removing existing installation...
Installing sidecar...
...
```