### PR TITLE
Fixes systemd filtering for disabled wires and processes

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -377,8 +377,8 @@ disable_unsupported_services() {
 restart_services() {
 	# We need to reload any of our changes to the systemd files before restarting
 	systemctl daemon-reload
-	systemctl list-unit-files | grep 'cyral-' | grep enabled | awk '{print $1}' | xargs -r systemctl restart
-	systemctl list-unit-files | grep 'cyral-' | grep disabled | awk '{print $1}' | xargs -r systemctl stop
+	systemctl list-unit-files --state=enabled | grep 'cyral-' | awk '{print $1}' | xargs -r systemctl restart
+	systemctl list-unit-files --state=disabled | grep 'cyral-' | awk '{print $1}' | xargs -r systemctl stop
 }
 
 # Perform all Post Installation Tasks


### PR DESCRIPTION
# Description

Changes systemd unit filtering for disabled wires from a grep based
approach to a systemd native filtering approach to account for different
systemd outputs.

The issue in question was that all services were being considered disabled because their presets were disabled, and that was resulting in a false positive for stopping services using systemctl.

## Testing

Deployed on Rocky linux, as well as RHEL.
