### PR TITLE
Do not clean local registry if CYRAL_SUPPORTED_REPOSITORIES is unset

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -378,7 +378,7 @@ disable_unsupported_services() {
 
 cleanup_local_registry() {
 	if command -v /opt/cyral/bin/cyral-local-discovery-cli &>/dev/null; then
- 		if [[ -n "CYRAL_REPOSITORIES_SUPPORTED" ]]; then
+ 		if [[ -n "$CYRAL_REPOSITORIES_SUPPORTED" ]]; then
 			echo "Cleaning up local registry"
 			readarray -t WIRES < <(find /etc/cyral/ -type d -name "*-wire" -printf "%f\n")
 			wires_to_disable=$(for wire in "${WIRES[@]}"; do if [[ ! "$CYRAL_REPOSITORIES_SUPPORTED" =~ $(echo "$wire" | cut -d- -f2) ]]; then echo -n "$wire "; fi; done)

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -378,15 +378,16 @@ disable_unsupported_services() {
 
 cleanup_local_registry() {
 	if command -v /opt/cyral/bin/cyral-local-discovery-cli &>/dev/null; then
-		echo "Cleaning up local registry"
-		readarray -t WIRES < <(find /etc/cyral/ -type d -name "*-wire" -printf "%f\n")
-		wires_to_disable=$(for wire in "${WIRES[@]}"; do if [[ ! "$CYRAL_REPOSITORIES_SUPPORTED" =~ $(echo "$wire" | cut -d- -f2) ]]; then echo -n "$wire "; fi; done)
-		for wire in "${WIRES[@]}"; do
-			if [[ -n "$wires_to_disable" ]] && [[ " ${wires_to_disable} " == *" ${wire} "* ]]; then
-				/opt/cyral/bin/cyral-local-discovery-cli unregister "${wire#cyral-}" --db "$CYRAL_REGISTRY_DATABASE" --bucket "$CYRAL_REGISTRY_BUCKET"
-			fi
-		done
-
+ 		if [[ -n "CYRAL_REPOSITORIES_SUPPORTED" ]]; then
+			echo "Cleaning up local registry"
+			readarray -t WIRES < <(find /etc/cyral/ -type d -name "*-wire" -printf "%f\n")
+			wires_to_disable=$(for wire in "${WIRES[@]}"; do if [[ ! "$CYRAL_REPOSITORIES_SUPPORTED" =~ $(echo "$wire" | cut -d- -f2) ]]; then echo -n "$wire "; fi; done)
+			for wire in "${WIRES[@]}"; do
+				if [[ -n "$wires_to_disable" ]] && [[ " ${wires_to_disable} " == *" ${wire} "* ]]; then
+					/opt/cyral/bin/cyral-local-discovery-cli unregister "${wire#cyral-}" --db "$CYRAL_REGISTRY_DATABASE" --bucket "$CYRAL_REGISTRY_BUCKET"
+				fi
+			done
+		fi
 		if [[ "$CYRAL_STORAGE_MANAGER_PROXY_ENABLED" != "true" ]]; then
 			/opt/cyral/bin/cyral-local-discovery-cli unregister "storage-proxy" --db "$CYRAL_REGISTRY_DATABASE" --bucket "$CYRAL_REGISTRY_BUCKET" 2>/dev/null || true
 		fi


### PR DESCRIPTION
As title, current code ends up unregistering _all_ wires if env var CYRAL_SUPPORTED_REPOSITORIES is unset