### PR TITLE
ENG-14549: Add push-client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ installed on the target machine.
 from the `Cyral Templates` option in the `Deployment` tab of your sidecar details.
 * Export the environment variable `CYRAL_SIDECAR_VERSION` with the desired sidecar
 version.
-* Run [install-linux.sh](https://github.com/cyral-quickstart/quickstart-sidecar-linux/blob/v0.1.0/install-linux.sh) as a super user.
+* Run [install-linux.sh](https://github.com/cyral-quickstart/quickstart-sidecar-linux/blob/main/install-linux.sh) as a super user.
 
 Use the command below as an example:
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -262,6 +262,9 @@ update_config_files() {
 	sed -i "/^http-gateway-address:/c\http-gateway-address: \"${CYRAL_CONTROL_PLANE}:$CYRAL_CONTROL_PLANE_HTTPS_PORT\"" /etc/cyral/cyral-forward-proxy/config.yaml
 	sed -i "/^token-url:/c\token-url: \"https://${CYRAL_CONTROL_PLANE}:$CYRAL_CONTROL_PLANE_HTTPS_PORT/v1/users/oidc/token\"" /etc/cyral/cyral-forward-proxy/config.yaml
 
+	# Push client config
+	sed -i "/^fqdn:/c\fqdn: \"${CYRAL_SIDECAR_ID}\"" /etc/cyral/cyral-push-client/config.yaml
+
 	# apply to all
 	for config_file in /etc/cyral/*/config.yaml; do
 		sed -i "/^sidecar-id:/c\sidecar-id: \"${CYRAL_SIDECAR_ID}\"" "$config_file"
@@ -273,13 +276,12 @@ update_config_files() {
 	sed -i "/^cert-key-filename:/c\cert-key-filename: \"${CYRAL_SIDECAR_TLS_PRIVATE_KEY:-key-tls.pem}\"" /etc/cyral/cyral-dispatcher/config.yaml
 	sed -i "/^ca-filename:/c\ca-filename: \"${CYRAL_SIDECAR_CA_CERT:-cert-tls.pem}\"" /etc/cyral/cyral-dispatcher/config.yaml
 
-	# In some sidecar versions the push-client config may not exist, thus we manually create it here:
+	# In some sidecar versions the push-client config may not exist, thus manually create it.
+	# This code can be removed after all sidecars are upgraded to v4.18 or later.
 	if [ ! -f "/etc/default/cyral-push-client" ]; then
 		cat > /etc/default/cyral-push-client <<EOF
 CYRAL_PUSH_CLIENT_FQDN="${CYRAL_SIDECAR_ID}"
 CYRAL_PUSH_CLIENT_PROXY_URL=http://localhost:8069
-ENDPOINTS=['localhost:8068']
-TIMEOUT=5
 EOF
 	fi
 


### PR DESCRIPTION
This PR introduces 3 changes:
1. Properly configure `fdqn` property in `/etc/cyral/cyral-push-client/config.yaml`.
2. Removes unused env vars wrongly added to `/etc/default/cyral-push-client`.
3. Fix `README`.

A comprehensive set of tests was performed to verify this change. Please check the comment in the Jira ticket.